### PR TITLE
Fix open facets handling in STDPolytope::intersect

### DIFF
--- a/src/hpnmg/datastructures/STDPolytope.tpp
+++ b/src/hpnmg/datastructures/STDPolytope.tpp
@@ -125,11 +125,14 @@ namespace hpnmg {
 
         auto newFacets = std::vector<Polytope>();
         newFacets.reserve(this->openFacets.size() + other.openFacets.size());
-        for (const auto &facet : this->openFacets) {
-            const auto newFacet = intersection.intersect(facet);
-            if (!newFacet.empty())
-                newFacets.push_back(newFacet);
+        for (const auto &oldFacets : {this->openFacets, other.openFacets}) {
+            for (const auto &facet : oldFacets) {
+                const auto newFacet = intersection.intersect(facet);
+                if (!newFacet.empty())
+                    newFacets.push_back(newFacet);
+            }
         }
+        //TODO: we might want to detect and remove duplicate facets here...
         newFacets.shrink_to_fit();
 
         return STDPolytope(intersection, newFacets);


### PR DESCRIPTION
The open facets of the `other` polytope were discarded, effectively
turning it into a closed one.

